### PR TITLE
Include acquiredBy support

### DIFF
--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -468,7 +468,7 @@ class MarketoClient:
         return result['success']  # there is no 'result' node returned in this call
 
     def push_lead(self, leads, lookupField, programName, programStatus=None, partitionName=None, source=None,
-                  reason=None):
+                  reason=None, acquiredBy=None):
         self.authenticate()
         if leads is None: raise ValueError("Invalid argument: required argument 'leads' is None.")
         if lookupField is None: raise ValueError("Invalid argument: required argument 'lookupField' is None.")
@@ -489,6 +489,8 @@ class MarketoClient:
             data['source'] = source
         if reason is not None:
             data['reason'] = reason
+        if acquiredBy is not None:
+            data['acquiredBy'] = acquiredBy
         result = self._api_call('post', self.host + "/rest/v1/leads/push.json", args, data)
         if result is None: raise Exception("Empty Response")
         if not result['success'] : raise MarketoException(result['errors'][0])

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ Originally developed by asamat with contributions from sandipsinha
 
 setup(
     name='marketorestpython',
-    version= '0.3.7',
+    version= '0.3.8',
     url='https://github.com/jepcastelein/marketo-rest-python',
     author='Jep Castelein',
     author_email='jep@castelein.net',


### PR DESCRIPTION
This PR allows setting the `acquiredBy` value when pushing a lead.
http://developers.marketo.com/rest-api/lead-database/leads/#crayon-5ac7d60d61f21286669478