### PR TITLE
[SGP-28899] Update `rateLimitedFunction` to Match Source

### DIFF
--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -34,7 +34,7 @@ class MarketoClient:
         self.requests_timeout = requests_timeout
 
     def _api_call(self, method, endpoint, *args, **kwargs):
-        request = HttpLib()
+        request = HttpLib(requests_timeout=self.requests_timeout)
         result = getattr(request, method)(endpoint, *args, **kwargs)
         self.API_CALLS_MADE += 1
         if self.API_LIMIT and self.API_CALLS_MADE >= self.API_LIMIT:

--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -19,7 +19,7 @@ class MarketoClient:
     scope = None
     last_request_id = None # intended to save last request id, but not used right now
 
-    def __init__(self, munchkin_id, client_id, client_secret, api_limit=None):
+    def __init__(self, munchkin_id, client_id, client_secret, api_limit=None, requests_timeout=None):
         assert(munchkin_id is not None)
         assert(client_id is not None)
         assert(client_secret is not None)
@@ -29,6 +29,9 @@ class MarketoClient:
         self.client_secret = client_secret
         self.API_CALLS_MADE = 0
         self.API_LIMIT = api_limit
+        if requests_timeout is not None:
+            assert isinstance(requests_timeout, int), "requests_timeout must be an integer"
+        self.requests_timeout = requests_timeout
 
     def _api_call(self, method, endpoint, *args, **kwargs):
         request = HttpLib()

--- a/marketorestpython/client.py
+++ b/marketorestpython/client.py
@@ -30,7 +30,19 @@ class MarketoClient:
         self.API_CALLS_MADE = 0
         self.API_LIMIT = api_limit
         if requests_timeout is not None:
-            assert isinstance(requests_timeout, int), "requests_timeout must be an integer"
+            error_message = "requests_timeout must be a postive float or int, or a two-element tuple of positive floats or ints"
+            if isinstance(requests_timeout, int) or isinstance(requests_timeout, float):
+                assert requests_timeout > 0, error_message
+                self.requests_timeout = requests_timeout
+            elif isinstance(requests_timeout, tuple):
+                assert (
+                        len(requests_timeout) == 2 and
+                        all(isinstance(x, int) or isinstance(x, float) for x in requests_timeout) and
+                        all(x > 0 for x in requests_timeout)
+                ), error_message
+                self.requests_timeout = requests_timeout
+            else:
+                raise AssertionError(error_message)
         self.requests_timeout = requests_timeout
 
     def _api_call(self, method, endpoint, *args, **kwargs):

--- a/marketorestpython/helper/http_lib.py
+++ b/marketorestpython/helper/http_lib.py
@@ -7,6 +7,9 @@ class HttpLib:
     sleep_duration = 3
     num_calls_per_second = 5  # can run five times per second at most (at 100/20 rate limit)
 
+    def __init__(self, requests_timeout=None):
+        self.requests_timeout = requests_timeout
+
     def _rate_limited(maxPerSecond):
         minInterval = 1.0 / float(maxPerSecond)
         def decorate(func):
@@ -30,7 +33,7 @@ class HttpLib:
                 return None
             try:
                 headers = {'Accept-Encoding': 'gzip'}
-                r = requests.get(endpoint, params=args, headers=headers)
+                r = requests.get(endpoint, params=args, headers=headers, timeout=self.requests_timeout)
                 if mode is 'nojson':
                     return r
                 else:
@@ -72,14 +75,14 @@ class HttpLib:
                 return None
             try:
                 if mode is 'nojsondumps':
-                    r = requests.post(endpoint, params=args, data=data)
+                    r = requests.post(endpoint, params=args, data=data, timeout=self.requests_timeout)
                 elif files is None:
                     headers = {'Content-type': 'application/json'}
-                    r = requests.post(endpoint, params=args, json=data, headers=headers)
+                    r = requests.post(endpoint, params=args, json=data, headers=headers, timeout=self.requests_timeout)
                 elif files is not None:
                     mimetype = mimetypes.guess_type(files)[0]
                     file = {filename: (files, open(files, 'rb'), mimetype)}
-                    r = requests.post(endpoint, params=args, json=data, files=file)
+                    r = requests.post(endpoint, params=args, json=data, files=file, timeout=self.requests_timeout)
                 r_json = r.json()
                 # if we still hit the rate limiter, do not return anything so the call will be retried
                 if 'success' in r_json:  # this is for all normal API calls (but not the access token call)
@@ -120,7 +123,7 @@ class HttpLib:
                 return None
             try:
                 headers = {'Content-type': 'application/json'}
-                r = requests.delete(endpoint, params=args, json=data, headers=headers)
+                r = requests.delete(endpoint, params=args, json=data, headers=headers, timeout=self.requests_timeout)
                 return r.json()
             except Exception as e:
                 print("HTTP Delete Exception! Retrying....."+ str(e))

--- a/marketorestpython/helper/http_lib.py
+++ b/marketorestpython/helper/http_lib.py
@@ -15,12 +15,12 @@ class HttpLib:
         def decorate(func):
             lastTimeCalled = [0.0]
             def rateLimitedFunction(*args,**kargs):
-                elapsed = time.clock() - lastTimeCalled[0]
+                elapsed = time.time() - lastTimeCalled[0]
                 leftToWait = minInterval - elapsed
                 if leftToWait>0:
                     time.sleep(leftToWait)
                 ret = func(*args,**kargs)
-                lastTimeCalled[0] = time.clock()
+                lastTimeCalled[0] = time.time()
                 return ret
             return rateLimitedFunction
         return decorate

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -24,8 +24,13 @@ def test_marketo_client(client):
     assert client.API_LIMIT == 20
     assert client.requests_timeout == 10
 
-    with pytest.raises(AssertionError):
-        MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', 20, requests_timeout="not an int")
+    client = MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', requests_timeout=(1,2.0))
+    assert client.requests_timeout == (1,2.0)
+
+    invalid_requests_timeouts = ["a string", -1, (1,2,3), (1, -1), (1,"a string"), (1,)]
+    for invalid_requests_timeout in invalid_requests_timeouts:
+        with pytest.raises(AssertionError):
+            MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', 20, requests_timeout=invalid_requests_timeout)
 
 
 @patch('marketorestpython.client.HttpLib')

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,9 +18,14 @@ def test_marketo_client(client):
     assert client.client_secret == 'supersecret'
     assert client.API_CALLS_MADE == 0
     assert client.API_LIMIT is None
+    assert client.requests_timeout is None
 
-    client = MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', 20)
+    client = MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', 20, requests_timeout=10)
     assert client.API_LIMIT == 20
+    assert client.requests_timeout == 10
+
+    with pytest.raises(AssertionError):
+        MarketoClient('123-FDY-456', 'randomclientid', 'supersecret', 20, requests_timeout="not an int")
 
 
 @patch('marketorestpython.client.HttpLib')


### PR DESCRIPTION
`time.clock` is deprecated. Update it to match source.

https://docs.python.org/3/whatsnew/3.8.html